### PR TITLE
pip --install-option is ignored, use more modern --target

### DIFF
--- a/src/compile.env
+++ b/src/compile.env
@@ -4,7 +4,7 @@ export PYTHONPATH=/var/vcap/packages/python-2.7/lib/python2.7/site-packages:$PYT
 function bosh_pip() {
   pip install \
     -I \
-    --install-option="--prefix=$BOSH_INSTALL_TARGET" \
+    --target="$BOSH_INSTALL_TARGET/lib/python2.7/site-packages/" \
     $@
 }
 
@@ -14,7 +14,7 @@ function bosh_pip_local() {
     --no-index \
     --find-links=file://`pwd`/deps \
     --no-allow-external  \
-    --install-option="--prefix=$BOSH_INSTALL_TARGET" \
+    --target="$BOSH_INSTALL_TARGET/lib/python2.7/site-packages/" \
     $@
 }
 


### PR DESCRIPTION
When I used `bosh_pip` to install a packages during compile time in my job, `pip` ignored the prefix and installed the packages in its default location. Thus, `$BOSH_INSTALL_TARGET` remained empty.

When I used `--target`, it worked fine, the packages ended up in `$BOSH_INSTALL_TARGET` of my job.