### PR TITLE
Bump Python to v2.7.15, setuptools to v40.4.3 and pip to v18.0

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,12 +1,9 @@
-Python-2.7.6.tgz:
-  size: 14725931
-  object_id: 702bfd9d-2520-4657-6ae4-4884d2f1d2b7
-  sha: 8328d9f1d55574a287df384f4931a3942f03da64
-pip-1.5.2.tar.gz:
-  size: 1079904
-  object_id: dda03a8f-08e7-4533-497d-1af4d4b6803e
-  sha: 4f43a6b04f83b8d83bee702750ff35be2a2b6af1
-setuptools-2.2.tar.gz:
-  size: 786831
-  object_id: 03b7171e-a8a5-420c-4328-1d8ac096c122
-  sha: 547eff11ea46613e8a9ba5b12a89c1010ecc4e51
+Python-2.7.15.tgz:
+  size: 17496336
+  sha: c9750707d127d39a6868e1e55f7cd8c7be006b89
+pip-18.0.tar.gz:
+  size: 1249656
+  sha: 337f4694bfcd4d698d9b02b38a7520fabc42a1d9
+setuptools-40.4.3.zip:
+  size: 854871
+  sha: a87d02021249fabcb13d516e509919ca6557610a

--- a/packages/python-2.7/packaging
+++ b/packages/python-2.7/packaging
@@ -1,44 +1,54 @@
+#!/usr/bin/env bash
+
 set -e
 
+python_version=2.7.15
+setuptools_version=40.4.3
+pip_version=18.0
+
+
 echo "Copying compile.env..."
-mkdir ${BOSH_INSTALL_TARGET}/bosh
-cp runtime.env ${BOSH_INSTALL_TARGET}/bosh/runtime.env
-cp compile.env ${BOSH_INSTALL_TARGET}/bosh/compile.env
+mkdir "${BOSH_INSTALL_TARGET}/bosh"
+cp runtime.env "${BOSH_INSTALL_TARGET}/bosh/runtime.env"
+cp compile.env "${BOSH_INSTALL_TARGET}/bosh/compile.env"
+
 
 echo "Extracting python..."
-tar xzvf Python-2.7.6.tgz
+tar -xzvf "Python-${python_version}.tgz"
 
 echo "Building python..."
-pushd Python-2.7.6
-  ./configure --prefix=$BOSH_INSTALL_TARGET
+pushd "Python-${python_version}"
+  ./configure --prefix="${BOSH_INSTALL_TARGET}"
   make
   make install
 popd
 
+
 echo "Extracting setuptools..."
-tar xzvf setuptools-2.2.tar.gz
+unzip "setuptools-${setuptools_version}.zip"
 
 echo "Creating the setuptools site packages..."
-mkdir -p $BOSH_INSTALL_TARGET/lib/python2.7/site-packages
+mkdir -p "${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages"
 
 echo "Setting the PYTHONPATH with setuptools site packages..."
-export PYTHONPATH=$BOSH_INSTALL_TARGET/lib/python2.7/site-packages:$PYTHONPATH
+export PYTHONPATH=${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages:${PYTHONPATH}
 
 echo "Installing setuptools..."
-pushd setuptools-2.2
-  /var/vcap/packages/python-2.7/bin/python setup.py install --prefix=$BOSH_INSTALL_TARGET
+pushd "setuptools-${setuptools_version}"
+  /var/vcap/packages/python-2.7/bin/python setup.py install --prefix="${BOSH_INSTALL_TARGET}"
 popd
 
+
 echo "Extracting pip..."
-tar xzvf pip-1.5.2.tar.gz
+tar -xzvf "pip-${pip_version}.tar.gz"
 
 echo "Creating the pip site packages..."
-mkdir -p $BOSH_INSTALL_TARGET/lib/python2.7/site-packages
+mkdir -p "${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages"
 
 echo "Setting the PYTHONPATH with setuptools and pip site packages..."
-export PYTHONPATH=$BOSH_INSTALL_TARGET/lib/python2.7/site-packages:$PYTHONPATH
+export PYTHONPATH=${BOSH_INSTALL_TARGET}/lib/python2.7/site-packages:${PYTHONPATH}
 
 echo "Installing pip..."
-pushd pip-1.5.2
-  /var/vcap/packages/python-2.7/bin/python setup.py install --prefix=$BOSH_INSTALL_TARGET
+pushd "pip-${pip_version}"
+  /var/vcap/packages/python-2.7/bin/python setup.py install --prefix="${BOSH_INSTALL_TARGET}"
 popd

--- a/scripts/add-blobs.sh
+++ b/scripts/add-blobs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -e
+
+python_version=2.7.15
+python_sha256=18617d1f15a380a919d517630a9cd85ce17ea602f9bbdc58ddc672df4b0239db
+
+setuptools_version=40.4.3
+setuptools_sha256=acbc5740dd63f243f46c2b4b8e2c7fd92259c2ddb55a4115b16418a2ed371b15
+
+pip_version=18.0
+pip_sha256=a0e11645ee37c90b40c46d607070c4fd583e2cd46231b1c06e389c5e814eed76
+
+
+function main() {
+    script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    release_dir=$(cd "${script_dir}/.." && pwd)
+
+    mkdir -p "${release_dir}/tmp"
+
+    set -x
+    download_add_blob \
+        "https://www.python.org/ftp/python/${python_version}/Python-${python_version}.tgz" \
+        "${python_sha256}" \
+        "${release_dir}/tmp/Python-${python_version}.tgz" \
+        "Python-${python_version}.tgz"
+
+    download_add_blob \
+        "https://files.pythonhosted.org/packages/6e/9c/6a003320b00ef237f94aa74e4ad66c57a7618f6c79d67527136e2544b728/setuptools-${setuptools_version}.zip" \
+        "${setuptools_sha256}" \
+        "${release_dir}/tmp/setuptools-${setuptools_version}.zip" \
+        "setuptools-${setuptools_version}.zip"
+
+    download_add_blob \
+        "https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-${pip_version}.tar.gz" \
+        "${pip_sha256}" \
+        "${release_dir}/tmp/pip-${pip_version}.tar.gz" \
+        "pip-${pip_version}.tar.gz"
+}
+
+function download_add_blob() {
+    local url=$1
+    local sha256=$2
+    local file_path=$3
+    local blob_path=$4
+
+    if [[ ! -f "${file_path}" ]]; then
+        curl -fsSL "${url}" -o "${file_path}"
+    fi
+    shasum -a 256 --check <<< "${sha256}  ${file_path}"
+
+    bosh add-blob "${file_path}" "${blob_path}"
+}
+
+main "$@"


### PR DESCRIPTION
Hi,

In this PR, I bump Python to v2.7.15, setuptools to v40.4.3 and pip to v18.0.
I also added an `add-blobs.sh` script that will help you download the same dependencies as I did.

Best,